### PR TITLE
Tame paddle impulse and add balance minigame

### DIFF
--- a/Assets/Scripts/Canoe/Main Canoe Scripts/BalanceMinigame.cs
+++ b/Assets/Scripts/Canoe/Main Canoe Scripts/BalanceMinigame.cs
@@ -1,0 +1,176 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.UI;
+
+/// <summary>
+/// Simple balancing mini-game inspired by Stardew Valley's fishing bar.
+/// A vertical target window drifts based on canoe roll + noise while the player
+/// nudges a smaller marker with A/D. Keeping the marker inside the window grants
+/// full authority to counter the canoe's wobble; slipping out reduces control.
+/// </summary>
+[DisallowMultipleComponent]
+public class BalanceMinigame : MonoBehaviour
+{
+    [Header("UI Layout")]
+    [SerializeField] Vector2 referenceResolution = new(1920f, 1080f);
+    [SerializeField] Vector2 anchoredPosition   = new(0f, 0f);
+    [SerializeField] Vector2 gaugeSize          = new(86f, 320f);
+    [SerializeField, Range(0.15f, 0.9f)] float targetWindowFraction = 0.38f;
+    [SerializeField, Range(0.08f, 0.6f)] float markerFraction       = 0.18f;
+
+    [Header("Gameplay")]
+    [SerializeField] float markerAcceleration = 6.5f;
+    [SerializeField] float markerDrag         = 6f;
+    [SerializeField] float markerReturn       = 3.5f;
+    [SerializeField] float targetDriftSpeed   = 1.15f;
+    [SerializeField] float targetNoiseAmp     = 0.55f;
+    [SerializeField] float targetNoiseFreq    = 0.8f;
+    [SerializeField] float rollInfluence      = 0.65f;
+    [SerializeField] float authoritySmooth    = 8f;
+    [SerializeField] float dangerAuthority    = 0.35f;
+    [SerializeField] Color gaugeColor         = new(0f, 0f, 0f, 0.6f);
+    [SerializeField] Color windowColor        = new(0.88f, 0.9f, 0.35f, 0.85f);
+    [SerializeField] Color markerSafeColor    = new(0.2f, 0.7f, 1f, 0.85f);
+    [SerializeField] Color markerDangerColor  = new(1f, 0.3f, 0.3f, 0.85f);
+
+    Canvas canvas;
+    RectTransform gaugeRect;
+    RectTransform targetRect;
+    RectTransform markerRect;
+    Image markerImage;
+
+    float markerPos;   // [-1,1]
+    float markerVel;
+    float targetPos;   // [-1,1]
+    float authority;
+    float rollBias;
+
+    float TargetHalf => Mathf.Clamp(targetWindowFraction * 0.5f, 0.08f, 0.45f);
+    float MarkerHalf => Mathf.Clamp(markerFraction * 0.5f, 0.04f, 0.45f);
+
+    public float Authority => authority;
+    public float ManualLean => Mathf.Clamp(markerPos, -1f, 1f);
+
+    void Awake()
+    {
+        BuildUI();
+    }
+
+    void OnEnable()
+    {
+        if (!canvas) BuildUI();
+        if (canvas) canvas.enabled = true;
+    }
+
+    void OnDisable()
+    {
+        if (canvas) canvas.enabled = false;
+    }
+
+    void OnDestroy()
+    {
+        if (canvas)
+        {
+            Destroy(canvas.gameObject);
+            canvas = null;
+        }
+    }
+
+    public void SetRollBias(float normalized)
+    {
+        rollBias = Mathf.Clamp(normalized, -1f, 1f);
+    }
+
+    void Update()
+    {
+        float dt = Time.deltaTime;
+        if (dt <= 0f) return;
+
+        var keyboard = Keyboard.current;
+        float input = 0f;
+        if (keyboard != null)
+        {
+            if (keyboard.aKey.isPressed) input -= 1f;
+            if (keyboard.dKey.isPressed) input += 1f;
+        }
+
+        // Player marker integrates acceleration with damping + spring toward centre.
+        markerVel += (input * markerAcceleration - markerPos * markerReturn) * dt;
+        markerVel = Mathf.MoveTowards(markerVel, 0f, markerDrag * dt);
+
+        float markerLimit = 1f - MarkerHalf;
+        markerPos = Mathf.Clamp(markerPos + markerVel * dt, -markerLimit, markerLimit);
+
+        // Target window drifts with roll bias + Perlin noise.
+        float noise = Mathf.PerlinNoise(Time.time * targetNoiseFreq, 0.37f) * 2f - 1f;
+        float desired = Mathf.Clamp(rollBias * rollInfluence + noise * targetNoiseAmp,
+                                    -1f + TargetHalf, 1f - TargetHalf);
+        targetPos = Mathf.MoveTowards(targetPos, desired, targetDriftSpeed * dt);
+
+        float distance = Mathf.Abs(markerPos - targetPos);
+        float rawAuthority = Mathf.Clamp01((TargetHalf - distance) / Mathf.Max(TargetHalf, 1e-3f));
+        float lerp = 1f - Mathf.Exp(-authoritySmooth * dt);
+        authority = Mathf.Lerp(authority, rawAuthority, lerp);
+
+        UpdateVisuals();
+    }
+
+    void BuildUI()
+    {
+        if (canvas) return;
+
+        canvas = new GameObject("BalanceMinigameCanvas").AddComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        canvas.sortingOrder = 35;
+
+        var scaler = canvas.gameObject.AddComponent<CanvasScaler>();
+        scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+        scaler.referenceResolution = referenceResolution;
+        canvas.gameObject.AddComponent<GraphicRaycaster>();
+
+        gaugeRect = new GameObject("BalanceGauge", typeof(RectTransform), typeof(Image))
+            .GetComponent<RectTransform>();
+        gaugeRect.SetParent(canvas.transform, false);
+        gaugeRect.anchorMin = gaugeRect.anchorMax = new Vector2(0.92f, 0.5f);
+        gaugeRect.sizeDelta = gaugeSize;
+        gaugeRect.anchoredPosition = anchoredPosition;
+        var gaugeImage = gaugeRect.GetComponent<Image>();
+        gaugeImage.color = gaugeColor;
+        gaugeImage.raycastTarget = false;
+
+        targetRect = new GameObject("TargetWindow", typeof(RectTransform), typeof(Image))
+            .GetComponent<RectTransform>();
+        targetRect.SetParent(gaugeRect, false);
+        targetRect.anchorMin = targetRect.anchorMax = new Vector2(0.5f, 0.5f);
+        targetRect.sizeDelta = new Vector2(gaugeSize.x * 0.82f, gaugeSize.y * targetWindowFraction);
+        var targetImage = targetRect.GetComponent<Image>();
+        targetImage.color = windowColor;
+        targetImage.raycastTarget = false;
+
+        markerRect = new GameObject("BalanceMarker", typeof(RectTransform), typeof(Image))
+            .GetComponent<RectTransform>();
+        markerRect.SetParent(gaugeRect, false);
+        markerRect.anchorMin = markerRect.anchorMax = new Vector2(0.5f, 0.5f);
+        markerRect.sizeDelta = new Vector2(gaugeSize.x * 0.6f, gaugeSize.y * markerFraction);
+        markerImage = markerRect.GetComponent<Image>();
+        markerImage.color = markerSafeColor;
+        markerImage.raycastTarget = false;
+
+        UpdateVisuals();
+    }
+
+    void UpdateVisuals()
+    {
+        if (!gaugeRect || !markerRect || !targetRect) return;
+
+        float gaugeHalf = gaugeRect.sizeDelta.y * 0.5f;
+        float markerHalf = markerRect.sizeDelta.y * 0.5f;
+        float targetHalf = targetRect.sizeDelta.y * 0.5f;
+
+        markerRect.anchoredPosition = new Vector2(0f, markerPos * Mathf.Max(0f, gaugeHalf - markerHalf));
+        targetRect.anchoredPosition = new Vector2(0f, targetPos * Mathf.Max(0f, gaugeHalf - targetHalf));
+
+        float danger = Mathf.Clamp01((dangerAuthority - authority) / Mathf.Max(dangerAuthority, 1e-3f));
+        markerImage.color = Color.Lerp(markerSafeColor, markerDangerColor, danger);
+    }
+}

--- a/Assets/Scripts/Canoe/Main Canoe Scripts/CanoeBalance.cs
+++ b/Assets/Scripts/Canoe/Main Canoe Scripts/CanoeBalance.cs
@@ -2,9 +2,11 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 
 /* CanoeBalance
- * Keeps the canoe upright with A/D counter-torque while water wobble tries to tip it.
- * Paddle hits temporarily make balancing harder.
- * Capsize calls PlayerHealth.Kill().
+ * Keeps the canoe upright by translating A/D input into counter-torque while
+ * water wobble tries to tip it. A BalanceMinigame UI mediates how much control
+ * the player has; slipping out of the target window amplifies wobble and weakens
+ * recovery. Paddle hits temporarily make balancing harder. Capsize calls
+ * PlayerHealth.Kill().
  */
 [RequireComponent(typeof(Rigidbody))]
 public class CanoeBalance : MonoBehaviour
@@ -21,6 +23,7 @@ public class CanoeBalance : MonoBehaviour
     [SerializeField] float wobbleAccel = 30f;     // torque accel
     [SerializeField] float wobbleHz    = 0.6f;    // sine base
     [SerializeField] float wobbleChaos = 0.35f;   // perlin mod
+    [SerializeField, Range(0f, 2f)] float wobbleFailBonus = 0.85f; // extra wobble when UI missed
 
     [Header("Hit Disruption")]
     [SerializeField] float hitKickDegrees   = 8f;   // roll kick impulse
@@ -28,8 +31,14 @@ public class CanoeBalance : MonoBehaviour
     [SerializeField] float harderDuration   = 2.5f; // seconds
     [SerializeField] float harderDecayPerSec= 1.2f; // smooth recovery
 
+    [Header("Balance Mini-game")]
+    [SerializeField] bool autoCreateMinigame   = true;
+    [SerializeField, Range(0f, 1f)] float minTorqueFactor   = 0.2f;
+    [SerializeField, Range(0f, 1f)] float minAutoRighting   = 0.35f;
+
     Rigidbody rb;
     PlayerHealth health;
+    BalanceMinigame minigame;
 
     float harderMult = 1f;
     float harderTimer = 0f;
@@ -39,34 +48,58 @@ public class CanoeBalance : MonoBehaviour
         rb = GetComponent<Rigidbody>();
         health = GetComponent<PlayerHealth>();
         if (rb.angularDamping < 0.05f) rb.angularDamping = 0.05f; // small damping keeps it lively
+
+        if (autoCreateMinigame)
+            minigame = GetComponent<BalanceMinigame>() ?? gameObject.AddComponent<BalanceMinigame>();
+        else
+            minigame = GetComponent<BalanceMinigame>();
     }
 
     void FixedUpdate()
     {
+        float roll = GetSignedRollDeg();
+        float capAngle = Mathf.Max(1f, Mathf.Abs(capsizeAngle));
+        float rollNorm = Mathf.Clamp(roll / capAngle, -1f, 1f);
+
+        float authority = 1f;
+        float input = 0f;
+
+        if (minigame && minigame.isActiveAndEnabled)
+        {
+            minigame.SetRollBias(rollNorm);
+            authority = Mathf.Clamp01(minigame.Authority);
+            input = minigame.ManualLean;
+        }
+        else
+        {
+            var kbd = Keyboard.current;
+            if (kbd != null)
+            {
+                if (kbd.aKey.isPressed) input -= 1f;
+                if (kbd.dKey.isPressed) input += 1f;
+            }
+        }
+
+        float torqueFactor = Mathf.Lerp(minTorqueFactor, 1f, authority);
+        float autoFactor = Mathf.Lerp(minAutoRighting, 1f, authority);
+        float wobbleFactor = 1f + (1f - authority) * wobbleFailBonus;
+
         // Water wobble around local Z (roll)
         float t = Time.time;
         float wobSin = Mathf.Sin(t * wobbleHz * Mathf.PI * 2f);
         float wobPer = Mathf.PerlinNoise(t * wobbleHz, t * wobbleChaos) * 2f - 1f;
         float wobble = wobSin * (1f + 0.6f * wobPer);
-        rb.AddRelativeTorque(Vector3.forward * (wobbleAccel * wobble * harderMult), ForceMode.Acceleration);
+        rb.AddRelativeTorque(Vector3.forward * (wobbleAccel * wobble * harderMult * wobbleFactor), ForceMode.Acceleration);
 
-        // Player input: A left, D right. Harder = less authority.
-        float input = 0f;
-        var kbd = Keyboard.current;
-        if (kbd != null)
-        {
-            if (kbd.aKey.isPressed) input -= 1f;
-            if (kbd.dKey.isPressed) input += 1f;
-        }
-        rb.AddRelativeTorque(Vector3.forward * (-inputTorqueAccel * input / Mathf.Max(1f, harderMult)), ForceMode.Acceleration);
+        // Player input: derived from balancing mini-game or fallback keyboard.
+        rb.AddRelativeTorque(Vector3.forward * (-inputTorqueAccel * input * torqueFactor / Mathf.Max(1f, harderMult)), ForceMode.Acceleration);
 
         // Auto-righting proportional to roll fraction
-        float roll = GetSignedRollDeg();
-        float righting = Mathf.Sign(roll) * Mathf.Min(Mathf.Abs(roll) / capsizeAngle, 1f);
-        rb.AddRelativeTorque(Vector3.forward * (-autoRightingAccel * righting), ForceMode.Acceleration);
+        float righting = Mathf.Sign(roll) * Mathf.Min(Mathf.Abs(roll) / capAngle, 1f);
+        rb.AddRelativeTorque(Vector3.forward * (-autoRightingAccel * righting * autoFactor), ForceMode.Acceleration);
 
         // Capsize check
-        if (Mathf.Abs(roll) >= capsizeAngle)
+        if (Mathf.Abs(roll) >= capAngle)
         {
             health?.Kill();
             rb.AddRelativeTorque(transform.forward * Mathf.Sign(roll) * 50f, ForceMode.Impulse);

--- a/Assets/Scripts/Canoe/Main Canoe Scripts/CanoePaddleController.cs
+++ b/Assets/Scripts/Canoe/Main Canoe Scripts/CanoePaddleController.cs
@@ -45,7 +45,10 @@ public class CanoePaddleController : MonoBehaviour
     [SerializeField] float catchRiseTime    = 0.08f;  // s ramp-in
     [SerializeField] float releaseFallTime  = 0.06f;  // s ramp-out
     [SerializeField] float forceSmoothing   = 12f;    // lerp-exp rate
-    [SerializeField] float antiTeleportDist = 1.5f;   // m/frame cap for tip delta
+    [SerializeField] float antiTeleportDist = 0.65f;  // m/frame cap for tip delta
+    [SerializeField] float maxTipSpeed      = 4.5f;   // clamp relative speed for stability
+    [SerializeField] float maxLinearAccel   = 5.5f;   // m/s^2 cap to keep canoe controllable
+    [SerializeField] float maxYawTorque     = 120f;   // N·m clamp for steering bias
     [Tooltip("Local blade face normal. Default assumes +X is blade face.")]
     [SerializeField] Vector3 bladeNormalLocal = Vector3.right;
 
@@ -94,6 +97,8 @@ public class CanoePaddleController : MonoBehaviour
         click.Enable();
 
         waterEffects = Object.FindFirstObjectByType<WaterEffectsManager>();
+
+        lastTip = PaddleTip();
     }
 
     void Update()
@@ -161,6 +166,12 @@ public class CanoePaddleController : MonoBehaviour
             Vector3 vPlane = Vector3.ProjectOnPlane(tipVel, Vector3.up);
             float   vMag   = vPlane.magnitude;
 
+            if (vMag > maxTipSpeed)
+            {
+                vPlane = vPlane.normalized * maxTipSpeed;
+                vMag = maxTipSpeed;
+            }
+
             if (vMag > 1e-3f)
             {
                 // Angle of attack based on blade face vs motion
@@ -175,9 +186,14 @@ public class CanoePaddleController : MonoBehaviour
                 Vector3 dragDir = -vPlane.normalized; // resist motion
                 hydroForce = dragDir * forceMag;
 
+                float maxForce = Mathf.Max(0f, rb.mass * maxLinearAccel);
+                if (maxForce > 0f && hydroForce.sqrMagnitude > maxForce * maxForce)
+                    hydroForce = hydroForce.normalized * maxForce;
+
                 // Optional yaw bias: convert lateral component into extra yaw torque
                 float lateral = Vector3.Dot(hydroForce, transform.right);
-                Vector3 yawTorque = Vector3.up * (lateral * yawBias);
+                float yawMag = Mathf.Clamp(lateral * yawBias, -maxYawTorque, maxYawTorque);
+                Vector3 yawTorque = Vector3.up * yawMag;
                 rb.AddTorque(yawTorque, ForceMode.Force);
             }
         }


### PR DESCRIPTION
## Summary
- clamp paddle tip speed and hydrodynamic force so the canoe no longer explodes forward when rowing
- add a BalanceMinigame UI that the player drives with A/D to keep within a drifting target and gate balance authority
- scale wobble/righting strength from the mini-game and auto-create the UI canvas when needed

## Testing
- not run (Unity editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc084b956483289deb7fdb3b49e782