### PR TITLE
Enhance balance UI and gameplay response

### DIFF
--- a/Assets/Scripts/Canoe/Main Canoe Scripts/BalanceMinigame.cs
+++ b/Assets/Scripts/Canoe/Main Canoe Scripts/BalanceMinigame.cs
@@ -13,7 +13,11 @@ public class BalanceMinigame : MonoBehaviour
     [Header("UI Layout")]
     [SerializeField] Vector2 referenceResolution = new(1920f, 1080f);
     [SerializeField] Vector2 anchoredPosition   = new(0f, 0f);
-    [SerializeField] Vector2 gaugeSize          = new(320f, 86f); // width, height
+    [SerializeField] Vector2 gaugeSize          = new(640f, 120f); // width, height
+    [SerializeField] Vector2 gaugeAnchor        = new(0.5f, 0.18f);
+    [SerializeField] float gaugeFramePadding    = 28f;
+    [SerializeField] Color gaugeFrameColor      = new(0f, 0f, 0f, 0.45f);
+    [SerializeField] Color gaugeFillColor       = new(1f, 1f, 1f, 0.12f);
     [SerializeField, Range(0.15f, 0.9f)] float targetWindowFraction = 0.38f;
     [SerializeField, Range(0.08f, 0.6f)] float markerFraction       = 0.18f;
 
@@ -64,8 +68,8 @@ public class BalanceMinigame : MonoBehaviour
     [SerializeField] float hitJitterAmplitude = 0.18f;
 
     Canvas canvas;
-    RectTransform gaugeRect, targetRect, markerRect;
-    Image markerImage;
+    RectTransform frameRect, gaugeRect, targetRect, markerRect, gaugeFillRect;
+    Image markerImage, gaugeFillImage;
 
     RectTransform miniRoot, miniCanoeRect, miniBubbleRect;
     Image miniBubbleImage, miniWaterImage;
@@ -78,6 +82,7 @@ public class BalanceMinigame : MonoBehaviour
 
     // Meters
     float authority, rollBias, rollDegrees, windowScale = 1f, hitOffset, hitJitterTimer;
+    float instability, targetOffset;
     float miniBubbleBaseY;
     Vector2 targetBaseSize;
 
@@ -86,6 +91,12 @@ public class BalanceMinigame : MonoBehaviour
 
     public float Authority => authority;
     public float ManualLean => Mathf.Clamp(markerPos, -1f, 1f);
+    public float Instability => Mathf.Clamp01(instability);
+    public float TargetOffset => targetOffset;
+    public float RollBias => rollBias;
+    public float MarkerNormalized => markerPos;
+    public float TargetNormalized => targetVisualPos;
+    public bool  InsideWindow => wasInside;
 
     public event Action<float> OnAuthorityChanged;
     public event Action<bool>  OnInsideWindowChanged;
@@ -99,9 +110,9 @@ public class BalanceMinigame : MonoBehaviour
     {
         if (!canvas) return;
         Destroy(canvas.gameObject); canvas=null;
-        gaugeRect=targetRect=markerRect=null;
+        frameRect=gaugeRect=targetRect=markerRect=gaugeFillRect=null;
         miniRoot=miniCanoeRect=miniBubbleRect=null;
-        miniBubbleImage=miniWaterImage=markerImage=null;
+        miniBubbleImage=miniWaterImage=markerImage=gaugeFillImage=null;
     }
 
     // —— Public API ——
@@ -120,6 +131,7 @@ public class BalanceMinigame : MonoBehaviour
     {
         markerPos=markerVel=markerTarget=0f; targetPos=targetVisualPos=0f;
         authority=1f; windowScale=1f; hitOffset=0f; hitJitterTimer=0f;
+        instability = 0f; targetOffset = 0f;
         UpdateVisuals(); RaiseInsideWindow(true); OnAuthorityChanged?.Invoke(authority);
     }
 
@@ -171,6 +183,8 @@ public class BalanceMinigame : MonoBehaviour
         // Authority
         float dist = Mathf.Abs(markerPos - targetVisualPos);
         float raw = Mathf.Clamp01((windowHalf - dist)/Mathf.Max(windowHalf,1e-3f));
+        instability = 1f - raw;
+        targetOffset = targetVisualPos - markerPos;
         float curved = Mathf.Pow(raw, authorityCurve);
         float aLerp = 1f - Mathf.Exp(-authoritySmooth * dt);
         float prev = authority;
@@ -192,15 +206,33 @@ public class BalanceMinigame : MonoBehaviour
         var scaler = canvas.gameObject.AddComponent<CanvasScaler>();
         scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
         scaler.referenceResolution = referenceResolution;
+        scaler.matchWidthOrHeight = 0.5f;
         canvas.gameObject.AddComponent<GraphicRaycaster>();
 
+        frameRect = new GameObject("BalanceGaugeFrame", typeof(RectTransform), typeof(Image)).GetComponent<RectTransform>();
+        frameRect.SetParent(canvas.transform, false);
+        frameRect.anchorMin = frameRect.anchorMax = gaugeAnchor;
+        frameRect.sizeDelta = gaugeSize + new Vector2(gaugeFramePadding * 2f, gaugeFramePadding * 2f);
+        frameRect.anchoredPosition = anchoredPosition;
+        var frameImage = frameRect.GetComponent<Image>();
+        frameImage.color = gaugeFrameColor; frameImage.raycastTarget = false;
+
         gaugeRect = new GameObject("BalanceGauge", typeof(RectTransform), typeof(Image)).GetComponent<RectTransform>();
-        gaugeRect.SetParent(canvas.transform, false);
-        gaugeRect.anchorMin = gaugeRect.anchorMax = new Vector2(0.5f, 0.15f); // bottom center
+        gaugeRect.SetParent(frameRect, false);
+        gaugeRect.anchorMin = gaugeRect.anchorMax = new Vector2(0.5f, 0.5f);
         gaugeRect.sizeDelta = gaugeSize;
-        gaugeRect.anchoredPosition = anchoredPosition;
+        gaugeRect.anchoredPosition = Vector2.zero;
         var gaugeImage = gaugeRect.GetComponent<Image>();
         gaugeImage.color = gaugeColor; gaugeImage.raycastTarget = false;
+
+        gaugeFillRect = new GameObject("GaugeFill", typeof(RectTransform), typeof(Image)).GetComponent<RectTransform>();
+        gaugeFillRect.SetParent(gaugeRect, false);
+        gaugeFillRect.anchorMin = new Vector2(0f, 0.5f);
+        gaugeFillRect.anchorMax = new Vector2(1f, 0.5f);
+        gaugeFillRect.sizeDelta = new Vector2(0f, gaugeSize.y * 0.45f);
+        gaugeFillRect.anchoredPosition = Vector2.zero;
+        gaugeFillImage = gaugeFillRect.GetComponent<Image>();
+        gaugeFillImage.color = gaugeFillColor; gaugeFillImage.raycastTarget = false;
 
         targetRect = new GameObject("TargetWindow", typeof(RectTransform), typeof(Image)).GetComponent<RectTransform>();
         targetRect.SetParent(gaugeRect, false);
@@ -264,6 +296,18 @@ public class BalanceMinigame : MonoBehaviour
     {
         if (!gaugeRect || !markerRect || !targetRect) return;
 
+        if (frameRect)
+        {
+            frameRect.anchorMin = frameRect.anchorMax = gaugeAnchor;
+            frameRect.sizeDelta = gaugeSize + new Vector2(gaugeFramePadding * 2f, gaugeFramePadding * 2f);
+            frameRect.anchoredPosition = anchoredPosition;
+        }
+
+        gaugeRect.sizeDelta = gaugeSize;
+
+        if (gaugeFillRect)
+            gaugeFillRect.sizeDelta = new Vector2(0f, gaugeSize.y * 0.45f);
+
         float gaugeHalf = gaugeRect.sizeDelta.x * 0.5f; // horizontal extent
 
         // Marker width scales; move along X
@@ -280,6 +324,14 @@ public class BalanceMinigame : MonoBehaviour
         // Colors
         float danger = Mathf.Clamp01((dangerAuthority - authority) / Mathf.Max(dangerAuthority, 1e-3f));
         markerImage.color = Color.Lerp(markerSafeColor, markerDangerColor, danger);
+
+        if (gaugeFillImage)
+        {
+            float wobble = Mathf.Lerp(1f, 1.6f, Mathf.Clamp01(instability));
+            Color fill = gaugeFillColor;
+            fill.a *= wobble;
+            gaugeFillImage.color = fill;
+        }
 
         UpdateMiniView();
     }

--- a/Assets/Scripts/Canoe/Main Canoe Scripts/CanoeBalanceAdapter.cs
+++ b/Assets/Scripts/Canoe/Main Canoe Scripts/CanoeBalanceAdapter.cs
@@ -24,15 +24,25 @@ public class CanoeBalanceAdapter : MonoBehaviour
     [SerializeField] float kd = 6f;  // Nm/(deg/s)
 
     [Header("Player Control")]
-    [SerializeField] float inputAccel = 120f;   // Nm/s from minigame lean
-    [SerializeField] float maxBalanceAccel = 220f; // Nm/s clamp
+    [SerializeField] float inputAccel = 165f;   // Nm/s from minigame lean
+    [SerializeField] float maxBalanceAccel = 320f; // Nm/s clamp
+    [SerializeField, Range(0f,1f)] float minInputAuthority = 0.2f;
+    [SerializeField] float inputAuthorityPower = 0.65f;
+
+    [Header("Stability Response")]
+    [SerializeField, Range(0f,1f)] float minPdAuthority = 0.06f;
+    [SerializeField] float pdAuthorityPower = 0.7f;
+    [SerializeField] float destabilizeBiasAccel = 60f;
+    [SerializeField] float destabilizeOffsetAccel = 75f;
 
     [Header("Wobble")]
-    [SerializeField] float wobbleAccel = 10f;  // Nm/s
-    [SerializeField] float wobbleHz = 0.35f;
+    [SerializeField] float wobbleAccel = 14f;  // Nm/s
+    [SerializeField] float wobbleHz = 0.42f;
     [SerializeField] float wobbleChaos = 0.22f;
+    [SerializeField] float wobbleSlew = 1.6f;
 
     Rigidbody rb;
+    float wobblePhase, wobbleEnvelope;
 
     void Awake()
     {
@@ -40,6 +50,12 @@ public class CanoeBalanceAdapter : MonoBehaviour
         if (!ui)      ui = FindFirstObjectByType<BalanceMinigame>();
         if (!health)  health = GetComponent<PlayerHealth>();
         if (rb.angularDamping < 0.08f) rb.angularDamping = 0.08f;
+    }
+
+    void OnEnable()
+    {
+        wobblePhase = Random.value * Mathf.PI * 2f;
+        wobbleEnvelope = 0f;
     }
 
     void FixedUpdate()
@@ -60,22 +76,37 @@ public class CanoeBalanceAdapter : MonoBehaviour
         // Player input from UI
         float authority = ui ? ui.Authority : 1f;           // 0..1
         float lean      = ui ? ui.ManualLean : 0f;          // -1..1
+        float instability = ui ? ui.Instability : 0f;
+        float instability01 = Mathf.Clamp01(instability);
+        float instabilityCurve = Mathf.SmoothStep(0f, 1f, instability01);
 
-        // PD toward upright, partially reduced when out of window
-        float pdScale   = Mathf.Lerp(0.25f, 1f, authority); // never zero
-        float pdTorque  = -(kp * rollDeg + kd * rollRate) * pdScale;
+        float authorityClamped = Mathf.Clamp01(authority);
+        float bias = ui ? ui.RollBias : Mathf.Clamp(rollDeg / Mathf.Max(1f, capsizeAngle), -1f, 1f);
+        float targetOffset = ui ? Mathf.Clamp(ui.TargetOffset, -1f, 1f) : 0f;
 
-        // Player torque scaled by authority
-        float playerTorque = -lean * inputAccel * authority;
+        // PD toward upright, heavily reduced when out of balance
+        float pdAuthority = Mathf.Lerp(minPdAuthority, 1f, Mathf.Pow(authorityClamped, pdAuthorityPower));
+        pdAuthority *= Mathf.Lerp(1f, 0.35f, instabilityCurve);
+        float pdTorque  = -(kp * rollDeg + kd * rollRate) * pdAuthority;
 
-        // Small wobble
-        float t = Time.time;
-        float wobSin = Mathf.Sin(t * wobbleHz * Mathf.PI * 2f);
-        float wobPer = Mathf.PerlinNoise(t * wobbleHz, t * wobbleChaos) * 2f - 1f;
-        float wobble = (wobSin * (1f + 0.5f * wobPer)) * wobbleAccel;
+        // Player torque scaled by authority but never fully zeroed
+        float inputAuthority = Mathf.Lerp(minInputAuthority, 1f, Mathf.Pow(authorityClamped, inputAuthorityPower));
+        float playerTorque = -lean * inputAccel * inputAuthority;
+
+        // Smooth wobble signal without harsh jitter
+        wobblePhase += Mathf.Max(0.05f, wobbleHz) * Mathf.PI * 2f * dt;
+        wobblePhase = Mathf.Repeat(wobblePhase, Mathf.PI * 2f);
+        float wobbleNoise = Mathf.PerlinNoise(Time.time * wobbleChaos, 0.37f) * 2f - 1f;
+        float wobbleLerp = 1f - Mathf.Exp(-Mathf.Max(0.01f, wobbleSlew) * dt);
+        wobbleEnvelope = Mathf.Lerp(wobbleEnvelope, wobbleNoise, wobbleLerp);
+        float wobble = Mathf.Sin(wobblePhase) * wobbleAccel * (0.55f + 0.45f * Mathf.Abs(wobbleEnvelope));
+        wobble *= Mathf.Lerp(0.6f, 1.8f, instabilityCurve);
+
+        // Push the canoe over when the player fails the minigame
+        float failureTorque = (bias * destabilizeBiasAccel + targetOffset * destabilizeOffsetAccel) * instabilityCurve;
 
         // Sum + clamp
-        float totalNmPerSec = Mathf.Clamp(pdTorque + playerTorque + wobble, -maxBalanceAccel, maxBalanceAccel);
+        float totalNmPerSec = Mathf.Clamp(pdTorque + playerTorque + wobble + failureTorque, -maxBalanceAccel, maxBalanceAccel);
         rb.AddRelativeTorque(Vector3.forward * totalNmPerSec, ForceMode.Acceleration);
 
         // Capsize check

--- a/Assets/Scripts/Canoe/Main Canoe Scripts/CanoePaddleController.cs
+++ b/Assets/Scripts/Canoe/Main Canoe Scripts/CanoePaddleController.cs
@@ -30,14 +30,15 @@ public class CanoePaddleController : MonoBehaviour
     [SerializeField] float CdMax  = 1.2f;
     [SerializeField] float fullSubmergeDepth = 0.20f;
     [SerializeField] float minCatchSpeed = 0.25f;
-    [SerializeField] float catchRiseTime = 0.07f;
-    [SerializeField] float releaseFallTime = 0.06f;
-    [SerializeField] float forceSmoothRate = 14f;
-    [SerializeField] float yawBias = 0.25f;
+    [SerializeField] float catchRiseTime = 0.05f;
+    [SerializeField] float releaseFallTime = 0.05f;
+    [SerializeField] float forceSmoothRate = 18f;
+    [SerializeField] float yawBias = 0.3f;
+    [SerializeField] float thrustMultiplier = 1.35f;
 
     [Header("Safety Caps")]
-    [SerializeField] float maxForceN = 220f;
-    [SerializeField] float maxTorqueNm = 350f;
+    [SerializeField] float maxForceN = 320f;
+    [SerializeField] float maxTorqueNm = 520f;
     [SerializeField] float maxLeverArm = 1.3f;
 
     [Header("Numerics")]
@@ -147,7 +148,7 @@ public class CanoePaddleController : MonoBehaviour
                 float Cd = Mathf.Lerp(CdBase, CdMax, aoa01);
 
                 float F = 0.5f * waterDensity * Cd * bladeArea * subm * v * v * catchBlend;
-                force = -vPlane.normalized * F;
+                force = -vPlane.normalized * F * thrustMultiplier;
 
                 if (force.magnitude > maxForceN) force = force.normalized * maxForceN;
             }


### PR DESCRIPTION
## Summary
- Rework the balance minigame HUD with a wider framed gauge, fill accent, and new instability telemetry accessors
- Tie canoe physics to the minigame’s instability to increase wobble, reduce righting torque, and apply failure torque when out of balance
- Improve paddle responsiveness by tightening catch timings, raising force limits, and adding a thrust multiplier

## Testing
- Not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd57dbb98083288f520fe681b3c9a6