### PR TITLE
Improve balance mechanics and paddle responsiveness

### DIFF
--- a/Assets/Scenes/MapGen.unity
+++ b/Assets/Scenes/MapGen.unity
@@ -3287,19 +3287,20 @@ MonoBehaviour:
   submergePitch: -35
   verticalDeadZone: 35
   waterDensity: 1000
-  bladeArea: 0.045
+  bladeArea: 0.055
   CdBase: 0.7
-  CdMax: 1.25
-  fullSubmergeDepth: 0.2
-  minCatchSpeed: 0.35
-  catchRiseTime: 0.08
+  CdMax: 1.35
+  fullSubmergeDepth: 0.22
+  minCatchSpeed: 0.3
+  catchRiseTime: 0.07
   releaseFallTime: 0.06
   forceSmoothRate: 14
   yawBias: 0.45
-  maxForceN: 220
-  maxTorqueNm: 350
-  maxLeverArm: 1.3
-  antiTeleportDist: 1.5
+  forceMultiplier: 1.35
+  maxForceN: 320
+  maxTorqueNm: 420
+  maxLeverArm: 1.35
+  antiTeleportDist: 1.6
   bladeNormalLocal: {x: 1, y: 0, z: 0}
 --- !u!54 &2113214471
 Rigidbody:
@@ -3472,17 +3473,17 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   referenceResolution: {x: 1920, y: 1080}
-  anchoredPosition: {x: 0, y: 0}
-  gaugeSize: {x: 86, y: 320}
-  targetWindowFraction: 0.38
-  markerFraction: 0.18
+  anchoredPosition: {x: 0, y: 120}
+  gaugeSize: {x: 560, y: 120}
+  targetWindowFraction: 0.32
+  markerFraction: 0.14
   markerHz: 3
   markerZeta: 1
   inputGain: 2.2
   recenterGain: 0.8
-  targetDriftSpeed: 1.15
-  targetNoiseAmp: 0.55
-  targetNoiseFreq: 0.8
+  targetDriftSpeed: 0.9
+  targetNoiseAmp: 0.35
+  targetNoiseFreq: 0.45
   rollInfluence: 0.65
   rollRateBoost: 0.4
   rollRateLowpass: 8
@@ -3493,8 +3494,8 @@ MonoBehaviour:
   windowColor: {r: 0.88, g: 0.9, b: 0.35, a: 0.85}
   markerSafeColor: {r: 0.2, g: 0.7, b: 1, a: 0.85}
   markerDangerColor: {r: 1, g: 0.3, b: 0.3, a: 0.85}
-  miniViewSize: {x: 220, y: 120}
-  miniViewOffset: {x: 0, y: -80}
+  miniViewSize: {x: 260, y: 140}
+  miniViewOffset: {x: 0, y: -72}
   miniBackgroundColor: {r: 0, g: 0, b: 0, a: 0.45}
   miniWaterColor: {r: 0.45, g: 0.65, b: 0.9, a: 0.4}
   miniCanoeColor: {r: 0.88, g: 0.42, b: 0.18, a: 0.9}
@@ -3508,7 +3509,7 @@ MonoBehaviour:
   hitTargetKick: 0.45
   hitTargetRecovery: 1.4
   hitJitterDuration: 0.75
-  hitJitterFrequency: 16
+  hitJitterFrequency: 5
   hitJitterAmplitude: 0.18
 --- !u!114 &2113214479
 MonoBehaviour:
@@ -3529,10 +3530,14 @@ MonoBehaviour:
   kp: 32
   kd: 6
   inputAccel: 120
-  maxBalanceAccel: 220
-  wobbleAccel: 10
-  wobbleHz: 0.35
-  wobbleChaos: 0.22
+  maxBalanceAccel: 320
+  wobbleAccel: 13
+  wobbleHz: 0.28
+  wobbleChaos: 0.2
+  wobbleAuthorityBoost: 2.6
+  imbalanceTorqueAccel: 170
+  imbalanceCurve: 1.45
+  imbalanceSmooth: 6.5
 --- !u!1 &2147398107
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Canoe/Main Canoe Scripts/BalanceMinigame.cs
+++ b/Assets/Scripts/Canoe/Main Canoe Scripts/BalanceMinigame.cs
@@ -12,10 +12,10 @@ public class BalanceMinigame : MonoBehaviour
 {
     [Header("UI Layout")]
     [SerializeField] Vector2 referenceResolution = new(1920f, 1080f);
-    [SerializeField] Vector2 anchoredPosition   = new(0f, 0f);
-    [SerializeField] Vector2 gaugeSize          = new(320f, 86f); // width, height
-    [SerializeField, Range(0.15f, 0.9f)] float targetWindowFraction = 0.38f;
-    [SerializeField, Range(0.08f, 0.6f)] float markerFraction       = 0.18f;
+    [SerializeField] Vector2 anchoredPosition   = new(0f, 120f);
+    [SerializeField] Vector2 gaugeSize          = new(560f, 120f); // width, height
+    [SerializeField, Range(0.15f, 0.9f)] float targetWindowFraction = 0.32f;
+    [SerializeField, Range(0.08f, 0.6f)] float markerFraction       = 0.14f;
 
     [Header("Marker Motion (2nd-order)")]
     [SerializeField] float markerHz = 3.0f;
@@ -24,9 +24,9 @@ public class BalanceMinigame : MonoBehaviour
     [SerializeField] float recenterGain = 0.8f;
 
     [Header("Target Drift")]
-    [SerializeField] float targetDriftSpeed = 1.15f;
-    [SerializeField] float targetNoiseAmp   = 0.45f;
-    [SerializeField] float targetNoiseFreq  = 0.8f;
+    [SerializeField] float targetDriftSpeed = 0.9f;
+    [SerializeField] float targetNoiseAmp   = 0.35f;
+    [SerializeField] float targetNoiseFreq  = 0.45f;
     [SerializeField] float rollInfluence    = 0.65f;
     [SerializeField] float rollRateBoost    = 0.4f;
     [SerializeField] float rollRateLowpass  = 8f;
@@ -43,8 +43,8 @@ public class BalanceMinigame : MonoBehaviour
     [SerializeField] Color markerDangerColor = new(1f, 0.3f, 0.3f, 0.85f);
 
     [Header("Mini View")]
-    [SerializeField] Vector2 miniViewSize = new(220f, 120f);
-    [SerializeField] Vector2 miniViewOffset = new(0f, -80f);
+    [SerializeField] Vector2 miniViewSize = new(260f, 140f);
+    [SerializeField] Vector2 miniViewOffset = new(0f, -72f);
     [SerializeField] Color miniBackgroundColor = new(0f, 0f, 0f, 0.45f);
     [SerializeField] Color miniWaterColor = new(0.45f, 0.65f, 0.9f, 0.4f);
     [SerializeField] Color miniCanoeColor = new(0.88f, 0.42f, 0.18f, 0.9f);
@@ -60,7 +60,7 @@ public class BalanceMinigame : MonoBehaviour
     [SerializeField] float hitTargetKick      = 0.45f;
     [SerializeField] float hitTargetRecovery  = 1.4f;
     [SerializeField] float hitJitterDuration  = 0.75f;
-    [SerializeField] float hitJitterFrequency = 16f;
+    [SerializeField] float hitJitterFrequency = 5f;
     [SerializeField] float hitJitterAmplitude = 0.18f;
 
     Canvas canvas;
@@ -86,6 +86,15 @@ public class BalanceMinigame : MonoBehaviour
 
     public float Authority => authority;
     public float ManualLean => Mathf.Clamp(markerPos, -1f, 1f);
+    public bool InsideWindow => wasInside;
+    public float BalanceErrorNormalized
+    {
+        get
+        {
+            float half = Mathf.Max(TargetHalf, 1e-3f);
+            return Mathf.Clamp((markerPos - targetVisualPos) / half, -1f, 1f);
+        }
+    }
 
     public event Action<float> OnAuthorityChanged;
     public event Action<bool>  OnInsideWindowChanged;
@@ -196,9 +205,11 @@ public class BalanceMinigame : MonoBehaviour
 
         gaugeRect = new GameObject("BalanceGauge", typeof(RectTransform), typeof(Image)).GetComponent<RectTransform>();
         gaugeRect.SetParent(canvas.transform, false);
-        gaugeRect.anchorMin = gaugeRect.anchorMax = new Vector2(0.5f, 0.15f); // bottom center
+        gaugeRect.anchorMin = gaugeRect.anchorMax = new Vector2(0.5f, 0.16f); // bottom center-ish
+        gaugeRect.pivot = new Vector2(0.5f, 0.5f);
         gaugeRect.sizeDelta = gaugeSize;
         gaugeRect.anchoredPosition = anchoredPosition;
+        gaugeRect.localRotation = Quaternion.identity;
         var gaugeImage = gaugeRect.GetComponent<Image>();
         gaugeImage.color = gaugeColor; gaugeImage.raycastTarget = false;
 

--- a/Assets/Scripts/Canoe/Main Canoe Scripts/CanoeBalanceAdapter.cs
+++ b/Assets/Scripts/Canoe/Main Canoe Scripts/CanoeBalanceAdapter.cs
@@ -31,8 +31,16 @@ public class CanoeBalanceAdapter : MonoBehaviour
     [SerializeField] float wobbleAccel = 10f;  // Nm/s
     [SerializeField] float wobbleHz = 0.35f;
     [SerializeField] float wobbleChaos = 0.22f;
+    [SerializeField] float wobbleAuthorityBoost = 2.2f;
+
+    [Header("Instability Punishment")]
+    [SerializeField] float imbalanceTorqueAccel = 140f;
+    [SerializeField] float imbalanceCurve = 1.45f;
+    [SerializeField] float imbalanceSmooth = 6f;
 
     Rigidbody rb;
+    float wobbleFiltered;
+    float imbalanceState;
 
     void Awake()
     {
@@ -40,6 +48,12 @@ public class CanoeBalanceAdapter : MonoBehaviour
         if (!ui)      ui = FindFirstObjectByType<BalanceMinigame>();
         if (!health)  health = GetComponent<PlayerHealth>();
         if (rb.angularDamping < 0.08f) rb.angularDamping = 0.08f;
+    }
+
+    void OnEnable()
+    {
+        wobbleFiltered = 0f;
+        imbalanceState = 0f;
     }
 
     void FixedUpdate()
@@ -58,11 +72,12 @@ public class CanoeBalanceAdapter : MonoBehaviour
         }
 
         // Player input from UI
-        float authority = ui ? ui.Authority : 1f;           // 0..1
-        float lean      = ui ? ui.ManualLean : 0f;          // -1..1
+        float authority   = ui ? ui.Authority : 1f;           // 0..1
+        float lean        = ui ? ui.ManualLean : 0f;          // -1..1
+        float balanceErr  = ui ? ui.BalanceErrorNormalized : 0f;
 
         // PD toward upright, partially reduced when out of window
-        float pdScale   = Mathf.Lerp(0.25f, 1f, authority); // never zero
+        float pdScale   = Mathf.Lerp(0.08f, 1f, authority); // never zero
         float pdTorque  = -(kp * rollDeg + kd * rollRate) * pdScale;
 
         // Player torque scaled by authority
@@ -72,10 +87,20 @@ public class CanoeBalanceAdapter : MonoBehaviour
         float t = Time.time;
         float wobSin = Mathf.Sin(t * wobbleHz * Mathf.PI * 2f);
         float wobPer = Mathf.PerlinNoise(t * wobbleHz, t * wobbleChaos) * 2f - 1f;
-        float wobble = (wobSin * (1f + 0.5f * wobPer)) * wobbleAccel;
+        float wobSample = (wobSin + wobPer) * 0.5f;
+        wobbleFiltered = Mathf.Lerp(wobbleFiltered, wobSample, 1f - Mathf.Exp(-3f * dt));
+        float wobbleStrength = Mathf.Lerp(1f, wobbleAuthorityBoost, Mathf.Clamp01(1f - authority));
+        float wobble = wobbleFiltered * wobbleAccel * wobbleStrength;
+
+        // Punish being outside the window with escalating torque
+        float errMagnitude = Mathf.Clamp01(Mathf.Abs(balanceErr));
+        float errSign = Mathf.Sign(balanceErr);
+        float imbalanceTarget = errSign * Mathf.Pow(errMagnitude, imbalanceCurve);
+        imbalanceState = Mathf.Lerp(imbalanceState, imbalanceTarget, 1f - Mathf.Exp(-imbalanceSmooth * dt));
+        float punishTorque = imbalanceState * imbalanceTorqueAccel;
 
         // Sum + clamp
-        float totalNmPerSec = Mathf.Clamp(pdTorque + playerTorque + wobble, -maxBalanceAccel, maxBalanceAccel);
+        float totalNmPerSec = Mathf.Clamp(pdTorque + playerTorque + wobble + punishTorque, -maxBalanceAccel, maxBalanceAccel);
         rb.AddRelativeTorque(Vector3.forward * totalNmPerSec, ForceMode.Acceleration);
 
         // Capsize check

--- a/Assets/Scripts/Canoe/Main Canoe Scripts/CanoePaddleController.cs
+++ b/Assets/Scripts/Canoe/Main Canoe Scripts/CanoePaddleController.cs
@@ -25,23 +25,24 @@ public class CanoePaddleController : MonoBehaviour
 
     [Header("Hydrodynamics")]
     [SerializeField] float waterDensity = 1000f;
-    [SerializeField] float bladeArea = 0.045f;
+    [SerializeField] float bladeArea = 0.055f;
     [SerializeField] float CdBase = 0.7f;
-    [SerializeField] float CdMax  = 1.2f;
-    [SerializeField] float fullSubmergeDepth = 0.20f;
-    [SerializeField] float minCatchSpeed = 0.25f;
+    [SerializeField] float CdMax  = 1.35f;
+    [SerializeField] float fullSubmergeDepth = 0.22f;
+    [SerializeField] float minCatchSpeed = 0.3f;
     [SerializeField] float catchRiseTime = 0.07f;
     [SerializeField] float releaseFallTime = 0.06f;
     [SerializeField] float forceSmoothRate = 14f;
-    [SerializeField] float yawBias = 0.25f;
+    [SerializeField] float yawBias = 0.45f;
+    [SerializeField] float forceMultiplier = 1.35f;
 
     [Header("Safety Caps")]
-    [SerializeField] float maxForceN = 220f;
-    [SerializeField] float maxTorqueNm = 350f;
-    [SerializeField] float maxLeverArm = 1.3f;
+    [SerializeField] float maxForceN = 320f;
+    [SerializeField] float maxTorqueNm = 420f;
+    [SerializeField] float maxLeverArm = 1.35f;
 
     [Header("Numerics")]
-    [SerializeField] float antiTeleportDist = 1.4f;
+    [SerializeField] float antiTeleportDist = 1.6f;
     [SerializeField] Vector3 bladeNormalLocal = Vector3.right;
 
     const float leanAngle = 8f, leanLerp = 6f;
@@ -147,7 +148,7 @@ public class CanoePaddleController : MonoBehaviour
                 float Cd = Mathf.Lerp(CdBase, CdMax, aoa01);
 
                 float F = 0.5f * waterDensity * Cd * bladeArea * subm * v * v * catchBlend;
-                force = -vPlane.normalized * F;
+                force = -vPlane.normalized * F * forceMultiplier;
 
                 if (force.magnitude > maxForceN) force = force.normalized * maxForceN;
             }


### PR DESCRIPTION
## Summary
- restyle the balance minigame gauge into a wide horizontal layout, smoothing its motion and exposing normalized error data
- escalate wobble torque and add an instability penalty when the player leaves the safe window, with tuned scene defaults to match
- boost paddle hydrodynamics and limits so canoe strokes translate into stronger forward motion

## Testing
- Not run (Unity project; no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68cd57dbb98083288f520fe681b3c9a6